### PR TITLE
Add nvidia GPU support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-
 #PLATFORM = intelfpga
 PLATFORM = intelgpu
+#PLATFORM = nvidia
 
 ifeq ($(PLATFORM),intelfpga)
 CXX=g++
-CFLAGS = -Wall -O2 -g -Wno-unknown-pragmas
+CFLAGS = -Wall -O2 -g -Wno-unknown-pragmas -DINTEL
 CFLAGS += $(shell aocl compile-config)
 CXXFLAGS = $(CFLAGS) -std=c++11
 LDFLAGS = $(shell aocl link-config)
@@ -12,7 +12,13 @@ endif
 
 ifeq ($(PLATFORM),intelgpu)
 CXX=g++
-CXXFLAGS = -Wall -O2 -g -std=gnu++0x
+CXXFLAGS = -Wall -O2 -g -std=gnu++0x -DINTEL
+LDFLAGS = -lOpenCL
+endif
+
+ifeq ($(PLATFORM),nvidia)
+CXX=nvcc
+CXXFLAGS = -O2 -std=c++11 -DNVIDIA
 LDFLAGS = -lOpenCL
 endif
 
@@ -36,13 +42,13 @@ INSTALL_PATH ?= /usr/local
 all: demohost daxpyhost slowpihost
 
 demohost : demohost.cpp clwrap.hpp
-	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+	$(CXX) -o $@ $< $(CXXFLAGS) $(LDFLAGS)
 
 daxpyhost : daxpyhost.cpp clwrap.hpp
-	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+	$(CXX) -o $@ $< $(CXXFLAGS) $(LDFLAGS)
 
 slowpihost : slowpihost.cpp clwrap.hpp
-	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+	$(CXX) -o $@ $< $(CXXFLAGS) $(LDFLAGS)
 
 demokernel.aocx : demokernel.cl
 	aoc -march=emulator -DEMULATOR $<

--- a/clwrap.hpp
+++ b/clwrap.hpp
@@ -243,7 +243,12 @@ public:
 		  Intel FPGA: "Intel(R) FPGA SDK for OpenCL(TM)"
 		  pocl: "Portable Computing Language"
 		 */
+    #ifdef INTEL
 		std::string pfkey = "Intel";
+    #endif
+    #ifdef NVIDIA
+		std::string pfkey = "CUDA";
+    #endif
 		if(const char *env = std::getenv("CLW_PF")) {
 			pfkey = env;
 			std::cout << "Platform search: " << pfkey << std::endl;
@@ -251,6 +256,7 @@ public:
 		platform_id = -1;
 		for (int i = 0; i < (int)pfs.size(); i++) {
 			std::string pn = pfs[i].getInfo<CL_PLATFORM_NAME>();
+      std::cout << pn << std::endl;
 			if (pn.find(pfkey.c_str()) != std::string::npos) {
 				platform_id = i;
 				break;


### PR DESCRIPTION
This pull request adds support for NVIDIA GPUs. Two basic changes needed to be made:

1. Adding an option in the makefile for the NVIDIA nvcc compiler toolchain.

2. Altering clwrap.hpp to search for platform name depending on a definition that is passed in via the makefile when selecting the compiler toolchain. I.e., if using the nvidia toolchain, it will now search for a platform key of "CUDA" instead of "Intel".

I tested this out and it seems to all work on a P100 using CUDA 10.0.130.